### PR TITLE
케이스타트업 조회수 크롤러 (재제출)

### DIFF
--- a/prisma/migrations/20251120114642_add_view_count/migration.sql
+++ b/prisma/migrations/20251120114642_add_view_count/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Program" ADD COLUMN "viewCount" INTEGER;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,6 +23,7 @@ model Program {
   startDate    DateTime?
   endDate      DateTime?
   status       String?   @default("open")
+  viewCount    Int?
   url          String?
   organizer    String?
   createdAt    DateTime  @default(now())

--- a/scripts/api/k-startup.js
+++ b/scripts/api/k-startup.js
@@ -1,8 +1,10 @@
 // K-Startup API (창업넷) 클라이언트
 import axios from 'axios'
+import * as cheerio from 'cheerio'
 
 const API_BASE_URL = process.env.K_STARTUP_API_URL
 const API_KEY = process.env.K_STARTUP_API_KEY
+const KSTARTUP_LIST_CATEGORIES = ['PBC010', 'PBC020'] // 모집중/마감임박 분류
 
 /**
  * K-Startup API에서 지원사업 데이터 가져오기
@@ -18,6 +20,9 @@ export async function fetchKStartupData() {
 
   try {
     console.log('📡 K-Startup API 호출 중...')
+
+    // 웹 목록에서 조회수 수집
+    const viewCountMap = await fetchKStartupViewCounts()
 
     // K-Startup API: 지원사업 공고 정보 조회
     const response = await axios.get(`${API_BASE_URL}/getAnnouncementInformation01`, {
@@ -36,18 +41,20 @@ export async function fetchKStartupData() {
     console.log(`✅ K-Startup: ${items.length}개 항목 수집`)
 
     for (const item of items) {
-      // sourceId validation: 제목과 날짜가 반드시 있어야 함
       const title = item.biz_pbanc_nm
       const startDate = item.pbanc_rcpt_bgng_dt
-
       if (!title || !startDate) {
         console.warn(`⚠️  K-Startup: 필수 정보 없는 항목 스킵 (title: ${title || 'unknown'})`)
         continue
       }
 
-      // 고유 ID 생성: 제목 일부 + 날짜
+      const pbancSn = item.pbanc_sn ?? item.pbancSn ?? null
+      const pbancKey = pbancSn ? String(pbancSn) : null
+
+      // 고유 ID: 가능하면 pbancSn 사용
       const titleSlug = title.replace(/[^a-zA-Z0-9가-힣]/g, '').slice(0, 30)
-      const id = `${titleSlug}-${startDate}`
+      const fallbackId = `${titleSlug}-${startDate}`
+      const sourceId = pbancKey ? `kstartup-${pbancKey}` : `kstartup-${fallbackId}`
 
       // 상태 판단: 종료일이 오늘보다 미래면 'open', 과거면 'closed'
       const endDate = item.pbanc_rcpt_end_dt
@@ -57,23 +64,26 @@ export async function fetchKStartupData() {
         status = endDateTime > new Date() ? 'open' : 'closed'
       }
 
+      const viewCount = pbancKey ? (viewCountMap.get(pbancKey) ?? null) : null
+
       programs.push({
         source: 'k-startup',
-        sourceId: `kstartup-${id}`,
-        title: title,
+        sourceId,
+        title,
         description: null, // API에서 제공하지 않음
         summary: null,
         category: item.supt_biz_clsfc || null,
-        region: null, // API에서 제공하지 않음
+        region: item.supt_regin || null,
         organizer: item.pbanc_ntrp_nm || null,
         target: item.aply_trgt || null,
         method: null,
         startDate: startDate ? new Date(startDate.replace(/(\d{4})(\d{2})(\d{2})/, '$1-$2-$3')) : null,
         endDate: endDate ? new Date(endDate.replace(/(\d{4})(\d{2})(\d{2})/, '$1-$2-$3')) : null,
-        url: null, // API에서 제공하지 않음
-        status: status,
+        url: item.detl_pg_url || null,
+        status,
         amountMin: null,
         amountMax: null,
+        viewCount,
       })
     }
 
@@ -91,4 +101,36 @@ export async function fetchKStartupData() {
   }
 
   return { data: programs, error: false }
+}
+
+async function fetchKStartupViewCounts(pages = 2) {
+  const viewMap = new Map()
+
+  for (const category of KSTARTUP_LIST_CATEGORIES) {
+    for (let page = 1; page <= pages; page++) {
+      const url = `https://www.k-startup.go.kr/web/contents/bizpbanc-ongoing.do?page=${page}&pbancClssCd=${category}`
+      try {
+        const res = await axios.get(url, {
+          timeout: 20000,
+          headers: { 'User-Agent': 'Mozilla/5.0' },
+        })
+
+        const body = String(res.data)
+        // go_view(12345) ... 조회 1,234 패턴 전역 검색
+        const regex = /go_view\((\d+)\)[\s\S]*?조회\s*([0-9,]+)/g
+        let match
+        while ((match = regex.exec(body)) !== null) {
+          const id = match[1]
+          const view = Number(match[2].replace(/,/g, ''))
+          if (Number.isFinite(view) && !viewMap.has(id)) {
+            viewMap.set(id, view)
+          }
+        }
+      } catch (error) {
+        console.warn(`⚠️  K-Startup viewCount 수집 실패 (category=${category}, page=${page}): ${error.message}`)
+      }
+    }
+  }
+
+  return viewMap
 }

--- a/scripts/ingest.js
+++ b/scripts/ingest.js
@@ -25,7 +25,8 @@ const ProgramInputSchema = z.object({
   endDate: z.date().nullable().optional(),
   status: z.string().nullable().optional(),
   url: z.string().nullable().optional(),
-  organizer: z.string().nullable().optional()
+  organizer: z.string().nullable().optional(),
+  viewCount: z.number().int().nullable().optional()
 })
 
 async function ingest() {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -212,6 +212,11 @@ export default async function HomePage({ searchParams }: PageProps) {
               {p.region ? <span>지역: {p.region} · </span> : null}
               {p.category ? <span>분야: {p.category}</span> : null}
             </div>
+            {(p.source === 'bizinfo' || p.source === 'k-startup') ? (
+              <div style={{ color: '#d00', fontSize: 13, marginTop: 4 }}>
+                조회수 {typeof p.viewCount === 'number' ? p.viewCount : 'null'}
+              </div>
+            ) : null}
             <p style={{ marginTop: 8 }}>{p.summary ?? summarize(p.description) ?? '요약 없음'}</p>
             <div style={{ fontSize: 13, color: '#888' }}>
               {p.startDate ? <span>시작: {new Date(p.startDate).toLocaleDateString()} · </span> : null}


### PR DESCRIPTION
## Summary
- K-Startup 공고번호(pbanc_sn) 기반 sourceId 및 조회수(viewCount) 크롤링/매핑
- 목록 페이지(go_view()+"조회 N") 정규식으로 조회수 추출, 상위 2페이지(PBC010/020) 수집
- K-Startup, Bizinfo 모두 조회수 UI 노출

## Testing
- npm run ingest (성공)
- dev 서버 재시작 후 K-Startup 필터에서 조회수 숫자 노출 확인
